### PR TITLE
Change TS Build from UMD to CJS

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "umd",
+    "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
## Issue
When building in Webpack, the following error is exhibited:

```
WARNING in ./~/ui-router-ng1-to-ng2/ng1-to-ng2.js
Critical dependencies:
15:24-31 require function is used in a way in which dependencies cannot be statically extracted
 @ ./~/ui-router-ng1-to-ng2/ng1-to-ng2.js 15:24-31
```

Upon further research, its related to the UMD output vs CJS. Switching to CJS should resolve this issue.

## Further Info
http://stackoverflow.com/questions/38392697/webpack-umd-critical-dependency-cannot-be-statically-extracted