### PR TITLE
Only include important files in npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "tsc": "tsc",
     "tsc:w": "tsc -w"
   },
+  "files": [
+    "ng1-to-ng2.js",
+    "ng1-to-ng2.ts",
+    "ng1-to-ng2.js.map",
+    "ng1-to-ng2.d.ts"
+  ],
   "license": "MIT",
   "peerDependencies": {
     "angular": "^1.5.0",


### PR DESCRIPTION
## Issue
When you do a webpack build, you receive the following error:

```
WARNING in ./~/ui-router-ng1-to-ng2/LICENSE
Module parse failed: /app/node_modules/ui-router-ng1-to-ng2/LICENSE Unexpected token (1:4)
You may need an appropriate loader to handle this file type.
SyntaxError: Unexpected token (1:4)
    at Parser.pp$4.raise (/app/node_modules/webpack/node_modules/acorn/dist/acorn.js:2221:15)
    at Parser.pp.unexpected (/app/node_modules/webpack/node_modules/acorn/dist/acorn.js:603:10)
    at Parser.pp.semicolon (/app/node_modules/webpack/node_modules/acorn/dist/acorn.js:581:61)
    at Parser.pp$1.parseExpressionStatement (/app/node_modules/webpack/node_modules/acorn/dist/acorn.js:966:10)
    at Parser.pp$1.parseStatement (/app/node_modules/webpack/node_modules/acorn/dist/acorn.js:730:24)
    at Parser.pp$1.parseTopLevel (/app/node_modules/webpack/node_modules/acorn/dist/acorn.js:638:25)
    at Parser.parse (/app/node_modules/webpack/node_modules/acorn/dist/acorn.js:516:17)
    at Object.parse (/app/node_modules/webpack/node_modules/acorn/dist/acorn.js:3098:39)
    at Parser.parse (/app/node_modules/webpack/lib/Parser.js:902:15)
    at DependenciesBlock.<anonymous> (/app/node_modules/webpack/lib/NormalModule.js:104:16)
    at DependenciesBlock.onModuleBuild (/app/node_modules/webpack-core/lib/NormalModuleMixin.js:310:10)
    at nextLoader (/app/node_modules/webpack-core/lib/NormalModuleMixin.js:275:25)
    at /app/node_modules/webpack-core/lib/NormalModuleMixin.js:259:5
    at Storage.finished (/app/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:38:16)
    at /app/node_modules/graceful-fs/graceful-fs.js:78:16
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:445:3)
 @ ./~/ui-router-ng1-to-ng2 ^\.\/.*$
```

You need to include only the important files like this: https://github.com/reactjs/redux/blob/master/package.json#L9

## Research
https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package